### PR TITLE
feat: Center upload media button

### DIFF
--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -282,8 +282,8 @@ export const Canvas: React.FC<CanvasProps> = ({
           )}
         </div>
       ) : (
-        <div className="w-full h-full flex items-center justify-center text-gray-500 text-lg sm:text-xl md:text-2xl font-semibold border-4 border-dashed border-gray-600 rounded-2xl">
-          <div className="p-4 text-center space-y-4">
+        <div className="w-full h-full flex items-center justify-center text-gray-500 text-lg sm:text-xl md:text-2xl font-semibold ">
+          <div className="p-4 text-center space-y-4 flex items-center justify-center flex-col">
             <p>Paste, drop, or upload media files</p>
             <button
               onClick={handleUploadClick}

--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -282,7 +282,7 @@ export const Canvas: React.FC<CanvasProps> = ({
           )}
         </div>
       ) : (
-        <div className="w-full h-full flex items-center justify-center text-gray-500 text-lg sm:text-xl md:text-2xl font-semibold ">
+        <div className="w-full h-full flex items-center justify-center text-gray-500 text-lg sm:text-xl md:text-2xl font-semibold border-4 border-dashed border-gray-600 rounded-2xl">
           <div className="p-4 space-y-4 flex items-center justify-center flex-col">
             <p>Paste, drop, or upload media files</p>
             <button

--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -283,7 +283,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         </div>
       ) : (
         <div className="w-full h-full flex items-center justify-center text-gray-500 text-lg sm:text-xl md:text-2xl font-semibold ">
-          <div className="p-4 text-center space-y-4 flex items-center justify-center flex-col">
+          <div className="p-4 space-y-4 flex items-center justify-center flex-col">
             <p>Paste, drop, or upload media files</p>
             <button
               onClick={handleUploadClick}


### PR DESCRIPTION
This commit centers the upload media button in the media area when no media is uploaded. This is achieved by applying flexbox properties to the container, ensuring the button is centered on all screen sizes.