### PR TITLE
Fix: Correctly position playback indicator during pan/zoom

### DIFF
--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -339,11 +339,10 @@ export const Canvas: React.FC<CanvasProps> = ({
 
       {replayCursorPos && (
         <div
-          className="absolute z-50 w-8 h-8 rounded-full bg-yellow-400 border-2 border-white shadow-lg pointer-events-none transition-transform duration-75"
+          className="absolute z-50 w-8 h-8 rounded-full bg-yellow-400 border-2 border-white shadow-lg pointer-events-none"
           style={{
-            left: 0,
-            top: 0,
-            transform: `translate(${replayCursorPos.x - 16}px, ${replayCursorPos.y - 16}px)`,
+            left: transform.x + replayCursorPos.x * transform.scale - 16,
+            top: transform.y + replayCursorPos.y * transform.scale - 16,
           }}
         >
           <div className="w-full h-full rounded-full bg-yellow-400 animate-ping"></div>


### PR DESCRIPTION
The playback indicator was previously positioned relative to the viewport, which caused it to appear in the wrong location during playback of pan and zoom actions.

This change corrects the positioning logic by taking the canvas's transform (pan and zoom) into account. The indicator is now correctly positioned relative to the canvas content, ensuring it remains synchronized during playback.